### PR TITLE
Add class for configuring the Tag1 Drush 9.x repo

### DIFF
--- a/manifests/drush9.pp
+++ b/manifests/drush9.pp
@@ -1,0 +1,32 @@
+# Class: yumrepos::drush9
+#
+# Installs the Drush 9.x yum repository.
+#
+class yumrepos::drush9 (
+  $drush9_url = $yumrepos::params::drush9_url,
+  $drush9_enabled = $yumrepos::params::drush9_enabled,
+  $drush9_gpgcheck = $yumrepos::params::drush9_gpgcheck,
+  $drush9_includepkgs = $yumrepos::params::drush9_includepkgs,
+  $drush9_exclude = $yumrepos::params::drush9_exclude,
+) inherits yumrepos::params {
+
+  file { '/etc/pki/rpm-gpg/RPM-GPG-KEY-TAG1':
+    ensure => present,
+    owner  => root,
+    group  => root,
+    mode   => '0644',
+    source => 'puppet:///modules/yumrepos/etc/pki/rpm-gpg/RPM-GPG-KEY-TAG1',
+  }
+
+  yumrepo { 'tag1-drush9':
+    descr       => 'Tag1 Drush 9',
+    baseurl     => $drush9_url,
+    enabled     => $drush9_enabled,
+    includepkgs => $drush9_includepkgs,
+    exclude     => $drush9_exclude,
+    gpgcheck    => $drush9_gpgcheck,
+    gpgkey      => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-TAG1',
+    require     => File['/etc/pki/rpm-gpg/RPM-GPG-KEY-TAG1'],
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -132,6 +132,13 @@ class yumrepos::params {
   $drush8_exclude = absent
   $drush8_gpgcheck = '1'
 
+  # Drush9 Settings.
+  $drush9_url = "http://pkg.tag1consulting.com/drush/drush-9/el${::operatingsystemmajrelease}/noarch"
+  $drush9_enabled = '1'
+  $drush9_includepkgs = absent
+  $drush9_exclude = absent
+  $drush9_gpgcheck = '1'
+
   # Zabbix Settings.
   $zabbix24_url = "http://repo.zabbix.com/zabbix/2.4/rhel/${::operatingsystemmajrelease}/${::architecture}"
   $zabbix24_enabled = '1'


### PR DESCRIPTION
Adds a ```yumrepos::drush9``` class for configuring the Drush 9.x yum repo.