### PR TITLE
Remove deprecated "hiera"

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "tag1-yumrepos",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "author": "Tag1 Consulting, Inc.",
   "summary": "Yum repo definitions for common repos (RHEL/CentOS).",
   "license": "BSD 3-Clause",
@@ -10,7 +10,6 @@
   "dependencies": [
 
   ],
-  "data_provider": "hiera",
   "description": "Provides multiple \"yumrepos::reponame\" classes used to create yum repos on CentOS/RHEL systems. Classes are parameterized so that common options are easily configurable with hiera. Includes GPG keys for repos where available.",
   "operatingsystem_support": [
     {


### PR DESCRIPTION
```
==> default: Warning: Defining "data_provider": "hiera" in metadata.json is deprecated. A 'hiera.yaml' file should be used instead
==> default:    (in /tmp/vagrant-puppet/environments/production/modules/yumrepos/metadata.json)
```